### PR TITLE
Slim + incremental refactor for all Google Ads performance streams

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -32,6 +32,7 @@ vars:
 
     # Googleads vars
     googleads_conversion_used_by_custom_conversions: 'all_conversions'   # Googleads custom conversions can use conversions or all_conversions
+    googleads_lookback_days: 31   # incremental reprocessing window; covers the 30-day conversion lookback + 1 day buffer
 
 models:
   bolt_dbt_googleads_package:
@@ -39,15 +40,66 @@ models:
     base:
       +schema: googleads_base
       +materialized: table
-      
-      _stg_googleads_shopping_insights:
-        +enabled: false
-      googleads_shopping_insights:
-        +enabled: false
+
+      # ---------------------------------------------------------------
+      # Redundant "currency + date parts" middle tables.
+      # The reporting models now read the _stg_*_insights day-grain models
+      # directly, so these are no longer needed.
+      # ---------------------------------------------------------------
+      googleads_campaigns_insights:         {+enabled: false}
+      googleads_ad_groups_insights:         {+enabled: false}
+      googleads_asset_groups_insights:      {+enabled: false}
+      googleads_ads_insights:               {+enabled: false}
+      googleads_keywords_insights:          {+enabled: false}
+      googleads_searchterms_insights:       {+enabled: false}
+      googleads_geo_insights:               {+enabled: false}
+      googleads_campaign_products_insights: {+enabled: false}
+      _stg_googleads_shopping_insights:     {+enabled: false}
+      googleads_shopping_insights:          {+enabled: false}
+
+      # ---------------------------------------------------------------
+      # Standalone metadata base models. Campaign/ad-group/asset-group
+      # metadata is now built inline inside the reporting models, so these
+      # do not need to run.
+      # ---------------------------------------------------------------
+      googleads_accounts:          {+enabled: false}
+      googleads_campaigns:         {+enabled: false}
+      googleads_ad_groups:         {+enabled: false}
+      googleads_asset_groups:      {+enabled: false}
+      googleads_ads:               {+enabled: false}
+      googleads_keywords:          {+enabled: false}
+      googleads_shopping_products: {+enabled: false}
+
+      # ---------------------------------------------------------------
+      # Optional entities: ad / keyword / searchterm.
+      # Kept in the package (and synced by Fivetran) but off by default.
+      # Enable per-client by overriding +enabled: true.
+      # ---------------------------------------------------------------
+      _stg_googleads_ads_insights:         {+enabled: false}
+      _stg_googleads_keywords_insights:    {+enabled: false}
+      _stg_googleads_searchterms_insights: {+enabled: false}
+
+      # ---------------------------------------------------------------
+      # Dropped entities: geo / campaign_product / shopping.
+      # Removed from the Fivetran sync as well.
+      # ---------------------------------------------------------------
+      _stg_googleads_geo_insights:               {+enabled: false}
+      _stg_googleads_campaign_products_insights: {+enabled: false}
 
     reporting:
       +schema: reporting
       +materialized: table
 
-      googleads_performance_by_shopping_product:
-        +enabled: false
+      # --- optional entities (off by default) ---
+      googleads_performance_by_ad:         {+enabled: false}
+      googleads_performance_by_ad_legacy:  {+enabled: false}
+      googleads_performance_by_keyword:    {+enabled: false}
+      googleads_performance_by_searchterm: {+enabled: false}
+
+      # --- legacy duplicate of the campaign model ---
+      googleads_performance_by_campaign_legacy: {+enabled: false}
+
+      # --- dropped entities ---
+      googleads_performance_by_geo:              {+enabled: false}
+      googleads_performance_by_campaign_product: {+enabled: false}
+      googleads_performance_by_shopping_product: {+enabled: false}

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -34,11 +34,6 @@ vars:
     googleads_conversion_used_by_custom_conversions: 'all_conversions'   # Googleads custom conversions can use conversions or all_conversions
     googleads_lookback_days: 31   # incremental reprocessing window; covers the 30-day conversion lookback + 1 day buffer
 
-    # Optional streams — off by default. Flip to true per-client (e.g. Erie) to
-    # build the (incremental) keyword / searchterm pipelines.
-    googleads_enable_keyword: false
-    googleads_enable_searchterm: false
-
 models:
   bolt_dbt_googleads_package:
     # Config indicated by + and applies to all files under models/example/
@@ -46,67 +41,14 @@ models:
       +schema: googleads_base
       +materialized: table
 
-      # ---------------------------------------------------------------
-      # Redundant "currency + date parts" middle tables.
-      # The reporting models now read the _stg_*_insights day-grain models
-      # directly, so these are no longer needed.
-      # ---------------------------------------------------------------
-      googleads_campaigns_insights:         {+enabled: false}
-      googleads_ad_groups_insights:         {+enabled: false}
-      googleads_asset_groups_insights:      {+enabled: false}
-      googleads_ads_insights:               {+enabled: false}
-      googleads_keywords_insights:          {+enabled: false}
-      googleads_searchterms_insights:       {+enabled: false}
-      googleads_geo_insights:               {+enabled: false}
-      googleads_campaign_products_insights: {+enabled: false}
-      _stg_googleads_shopping_insights:     {+enabled: false}
-      googleads_shopping_insights:          {+enabled: false}
-
-      # ---------------------------------------------------------------
-      # Standalone metadata base models. Campaign/ad-group/asset-group
-      # metadata is now built inline inside the reporting models, so these
-      # do not need to run.
-      # ---------------------------------------------------------------
-      googleads_accounts:          {+enabled: false}
-      googleads_campaigns:         {+enabled: false}
-      googleads_ad_groups:         {+enabled: false}
-      googleads_asset_groups:      {+enabled: false}
-      googleads_ads:               {+enabled: false}
-      googleads_keywords:          {+enabled: false}
-      googleads_shopping_products: {+enabled: false}
-
-      # ---------------------------------------------------------------
-      # Optional entities: ad / keyword / searchterm.
-      # Kept in the package (and synced by Fivetran) but off by default.
-      # keyword / searchterm are refactored to the slim+incremental pattern and
-      # gated by a var. ad is not yet refactored — enable explicitly if needed
-      # (it still depends on its middle/base-metadata models).
-      # ---------------------------------------------------------------
-      _stg_googleads_ads_insights:         {+enabled: false}
-      _stg_googleads_keywords_insights:    {+enabled: "{{ var('googleads_enable_keyword', false) }}"}
-      _stg_googleads_searchterms_insights: {+enabled: "{{ var('googleads_enable_searchterm', false) }}"}
-
-      # ---------------------------------------------------------------
-      # Dropped entities: geo / campaign_product / shopping.
-      # Removed from the Fivetran sync as well.
-      # ---------------------------------------------------------------
-      _stg_googleads_geo_insights:               {+enabled: false}
-      _stg_googleads_campaign_products_insights: {+enabled: false}
+      _stg_googleads_shopping_insights:
+        +enabled: false
+      googleads_shopping_insights:
+        +enabled: false
 
     reporting:
       +schema: reporting
       +materialized: table
 
-      # --- optional entities (off by default; keyword/searchterm var-gated) ---
-      googleads_performance_by_ad:         {+enabled: false}
-      googleads_performance_by_ad_legacy:  {+enabled: false}
-      googleads_performance_by_keyword:    {+enabled: "{{ var('googleads_enable_keyword', false) }}"}
-      googleads_performance_by_searchterm: {+enabled: "{{ var('googleads_enable_searchterm', false) }}"}
-
-      # --- legacy duplicate of the campaign model ---
-      googleads_performance_by_campaign_legacy: {+enabled: false}
-
-      # --- dropped entities ---
-      googleads_performance_by_geo:              {+enabled: false}
-      googleads_performance_by_campaign_product: {+enabled: false}
-      googleads_performance_by_shopping_product: {+enabled: false}
+      googleads_performance_by_shopping_product:
+        +enabled: false

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -34,6 +34,11 @@ vars:
     googleads_conversion_used_by_custom_conversions: 'all_conversions'   # Googleads custom conversions can use conversions or all_conversions
     googleads_lookback_days: 31   # incremental reprocessing window; covers the 30-day conversion lookback + 1 day buffer
 
+    # Optional streams — off by default. Flip to true per-client (e.g. Erie) to
+    # build the (incremental) keyword / searchterm pipelines.
+    googleads_enable_keyword: false
+    googleads_enable_searchterm: false
+
 models:
   bolt_dbt_googleads_package:
     # Config indicated by + and applies to all files under models/example/
@@ -73,11 +78,13 @@ models:
       # ---------------------------------------------------------------
       # Optional entities: ad / keyword / searchterm.
       # Kept in the package (and synced by Fivetran) but off by default.
-      # Enable per-client by overriding +enabled: true.
+      # keyword / searchterm are refactored to the slim+incremental pattern and
+      # gated by a var. ad is not yet refactored — enable explicitly if needed
+      # (it still depends on its middle/base-metadata models).
       # ---------------------------------------------------------------
       _stg_googleads_ads_insights:         {+enabled: false}
-      _stg_googleads_keywords_insights:    {+enabled: false}
-      _stg_googleads_searchterms_insights: {+enabled: false}
+      _stg_googleads_keywords_insights:    {+enabled: "{{ var('googleads_enable_keyword', false) }}"}
+      _stg_googleads_searchterms_insights: {+enabled: "{{ var('googleads_enable_searchterm', false) }}"}
 
       # ---------------------------------------------------------------
       # Dropped entities: geo / campaign_product / shopping.
@@ -90,11 +97,11 @@ models:
       +schema: reporting
       +materialized: table
 
-      # --- optional entities (off by default) ---
+      # --- optional entities (off by default; keyword/searchterm var-gated) ---
       googleads_performance_by_ad:         {+enabled: false}
       googleads_performance_by_ad_legacy:  {+enabled: false}
-      googleads_performance_by_keyword:    {+enabled: false}
-      googleads_performance_by_searchterm: {+enabled: false}
+      googleads_performance_by_keyword:    {+enabled: "{{ var('googleads_enable_keyword', false) }}"}
+      googleads_performance_by_searchterm: {+enabled: "{{ var('googleads_enable_searchterm', false) }}"}
 
       # --- legacy duplicate of the campaign model ---
       googleads_performance_by_campaign_legacy: {+enabled: false}

--- a/models/base/_stg_googleads_ad_groups_insights.sql
+++ b/models/base/_stg_googleads_ad_groups_insights.sql
@@ -64,6 +64,6 @@ LEFT JOIN convtype USING(date, ad_group_id)
 {%- endif %}
 {% if is_incremental() -%}
 
-where date >= (select max(date)-30 from {{ this }})
+where date >= (select max(date) - {{ var('googleads_lookback_days', 31) }} from {{ this }})
 
 {% endif %}

--- a/models/base/_stg_googleads_ads_insights.sql
+++ b/models/base/_stg_googleads_ads_insights.sql
@@ -129,6 +129,6 @@ LEFT JOIN convtype USING(date, ad_id, ad_group_id)
 {%- endif %}
 {% if is_incremental() -%}
 
-where date >= (select max(date)-30 from {{ this }})
+where date >= (select max(date) - {{ var('googleads_lookback_days', 31) }} from {{ this }})
 
 {% endif %}

--- a/models/base/_stg_googleads_asset_groups_insights.sql
+++ b/models/base/_stg_googleads_asset_groups_insights.sql
@@ -64,6 +64,6 @@ LEFT JOIN convtype USING(date, asset_group_id)
 {%- endif %}
 {% if is_incremental() -%}
 
-where date >= (select max(date)-30 from {{ this }})
+where date >= (select max(date) - {{ var('googleads_lookback_days', 31) }} from {{ this }})
 
 {% endif %}

--- a/models/base/_stg_googleads_campaigns_insights.sql
+++ b/models/base/_stg_googleads_campaigns_insights.sql
@@ -76,6 +76,6 @@ LEFT JOIN convtype USING(date, campaign_id)
 {%- endif %}
 {% if is_incremental() -%}
 
-where date >= (select max(date)-30 from {{ this }})
+where date >= (select max(date) - {{ var('googleads_lookback_days', 31) }} from {{ this }})
 
 {% endif %}

--- a/models/base/_stg_googleads_keywords_insights.sql
+++ b/models/base/_stg_googleads_keywords_insights.sql
@@ -72,6 +72,6 @@ LEFT JOIN convtype USING(date, ad_group_id, keyword_id)
 {%- endif %}
 {% if is_incremental() -%}
 
-where date >= (select max(date)-30 from {{ this }})
+where date >= (select max(date) - {{ var('googleads_lookback_days', 31) }} from {{ this }})
 
 {% endif %}

--- a/models/base/_stg_googleads_searchterms_insights.sql
+++ b/models/base/_stg_googleads_searchterms_insights.sql
@@ -74,6 +74,6 @@ LEFT JOIN convtype USING(date, keyword_ad_group_criterion, search_term, search_t
 {%- endif %}
 {% if is_incremental() -%}
 
-where date >= (select max(date)-30 from {{ this }})
+where date >= (select max(date) - {{ var('googleads_lookback_days', 31) }} from {{ this }})
 
 {% endif %}

--- a/models/reporting/googleads_performance_by_ad.sql
+++ b/models/reporting/googleads_performance_by_ad.sql
@@ -1,6 +1,23 @@
 {{ config (
-    alias = target.database + '_googleads_performance_by_ad'
+    alias = target.database + '_googleads_performance_by_ad',
+    materialized = 'incremental',
+    unique_key = 'unique_key',
+    incremental_strategy = 'delete+insert',
+    on_schema_change = 'append_new_columns'
 )}}
+
+{#-
+    Ad performance, all date granularities in one table.
+
+    Reads the day-grain incremental staging model directly (no redundant
+    googleads_ads_insights middle table), applies currency conversion + date
+    parts, rolls up day/week/month/quarter/year, and joins ad / ad group /
+    campaign / account metadata built inline from the raw history tables.
+
+    Incremental: daily runs reprocess from the start of the year containing
+    (max date - googleads_lookback_days). Run --full-refresh weekly to rebuild
+    history and refresh object names/status on older rows.
+-#}
 
 {%- set currency_fields = [
     "spend"
@@ -9,7 +26,9 @@
 
 {%- set exclude_fields = [
     "unique_key",
+    "_fivetran_id",
     "_fivetran_synced",
+    "last_updated",
     "account_id",
     "account_name",
     "account_currency_code",
@@ -89,9 +108,12 @@ WITH
     {%- if var('currency') != 'USD' %}
     LEFT JOIN currency USING(date)
     {%- endif %}
+    {% if is_incremental() -%}
+    where date >= date_trunc('year', (select dateadd(day,-{{ var('googleads_lookback_days', 31) }},max(date)) from {{ this }}))::date
+    {%- endif %}
     ),
 
-    insights_stg AS 
+    insights_stg AS
     (SELECT *,
     {{ get_date_parts('date') }}
     FROM insights),
@@ -191,14 +213,13 @@ WITH
     ),
 
 {%- set date_granularity_list = ['day','week','month','quarter','year'] -%}
-{%- set exclude_fields = ['date','day','week','month','quarter','year','last_updated','unique_key'] -%}
+{%- set measure_exclude = ['date','day','week','month','quarter','year','last_updated','unique_key','end_date_time','start_date_time'] -%}
 {%- set dimensions = ['ad_group_id','ad_id'] -%}
-{%- set measures = adapter.get_columns_in_relation(ref('googleads_ads_insights'))
-                    |map(attribute="name")
-                    |reject("in",exclude_fields)
+{%- set measures = stg_fields
+                    |reject("in",measure_exclude)
                     |reject("in",dimensions)
                     |list
-                    -%}  
+                    -%}
  
     {%- for date_granularity in date_granularity_list %}
 

--- a/models/reporting/googleads_performance_by_ad.sql
+++ b/models/reporting/googleads_performance_by_ad.sql
@@ -80,7 +80,8 @@
 {%- set stg_fields = adapter.get_columns_in_relation(ref('_stg_googleads_ads_insights'))
                     |map(attribute="name")
                     |reject("in",exclude_fields)
-                    -%}  
+                    |list
+                    -%}
 
 WITH 
     {% if var('currency') != 'USD' -%}

--- a/models/reporting/googleads_performance_by_ad_group.sql
+++ b/models/reporting/googleads_performance_by_ad_group.sql
@@ -1,22 +1,190 @@
 {{ config (
-    alias = target.database + '_googleads_performance_by_ad_group'
+    alias = target.database + '_googleads_performance_by_ad_group',
+    materialized = 'incremental',
+    unique_key = 'unique_key',
+    incremental_strategy = 'delete+insert',
+    on_schema_change = 'append_new_columns'
 )}}
 
-{%- set date_granularity_list = ['day','week','month','quarter','year'] -%}
-{%- set exclude_fields = ['date','day','week','month','quarter','year','type','last_updated','unique_key'] -%}
-{%- set dimensions = ['ad_group_id'] -%}
-{%- set measures = adapter.get_columns_in_relation(ref('googleads_ad_groups_insights'))
+{#-
+    Ad group performance, all date granularities in one table.
+
+    Reads the day-grain incremental staging model directly (no redundant
+    googleads_ad_groups_insights middle table), applies currency conversion +
+    date parts, rolls up day/week/month/quarter/year, and joins ad group +
+    campaign + account metadata built inline from the raw history tables.
+
+    Incremental: daily runs reprocess from the start of the year containing
+    (max date - googleads_lookback_days). Run --full-refresh weekly to rebuild
+    all history and refresh object names/status on older rows.
+-#}
+
+{%- set currency_fields = [
+    "spend"
+]
+-%}
+
+{%- set exclude_fields = [
+    "unique_key",
+    "_fivetran_id",
+    "_fivetran_synced",
+    "customer_time_zone",
+    "campaign",
+    "day_of_week",
+    "last_updated",
+    "ad_group_name",
+    "ad_group_status",
+    "campaign_id",
+    "account_id",
+    "account_currency_code",
+    "campaign_name",
+    "account_name",
+    "campaign_status",
+    "advertising_channel_type",
+    "gmail_saves",
+    "gmail_forwards",
+    "gmail_secondary_clicks",
+    "content_impression_share",
+    "content_budget_lost_impression_share",
+    "content_rank_lost_impression_share",
+    "video_quartile_p_25_rate",
+    "campaign_budget_has_recommended_budget",
+    "campaign_budget_recommended_budget_amount_micros",
+    "campaign_budget",
+    "campaign_budget_period",
+    "campaign_budget_total_amount_micros",
+    "campaign_budget_explicitly_shared",
+    "interactions",
+    "active_view_measurability",
+    "active_view_viewability",
+    "active_view_measurable_cost_micros"
+]
+-%}
+
+{%- set stg_fields = adapter.get_columns_in_relation(ref('_stg_googleads_ad_groups_insights'))
                     |map(attribute="name")
                     |reject("in",exclude_fields)
+                    |list
+                    -%}
+
+WITH
+    {% if var('currency') != 'USD' -%}
+    currency AS
+    (SELECT DISTINCT date, "{{ var('currency') }}" as raw_rate,
+        LAG(raw_rate) ignore nulls over (order by date) as exchange_rate
+    FROM utilities.dates
+    LEFT JOIN utilities.currency USING(date)
+    WHERE date <= current_date),
+    {%- endif -%}
+
+    {%- set exchange_rate = 1 if var('currency') == 'USD' else 'exchange_rate' %}
+
+    insights AS
+    (SELECT
+        {%- for field in stg_fields -%}
+        {%- if field in currency_fields or '_value' in field %}
+        "{{ field }}"::float/{{ exchange_rate }} as "{{ field }}"
+        {%- else %}
+        "{{ field }}"
+        {%- endif -%}
+        {%- if not loop.last %},{%- endif %}
+        {%- endfor %}
+    FROM {{ ref('_stg_googleads_ad_groups_insights') }}
+    {%- if var('currency') != 'USD' %}
+    LEFT JOIN currency USING(date)
+    {%- endif %}
+    {% if is_incremental() -%}
+    where date >= date_trunc('year', (select dateadd(day,-{{ var('googleads_lookback_days', 31) }},max(date)) from {{ this }}))::date
+    {%- endif %}
+    ),
+
+    insights_stg AS
+    (SELECT *,
+    {{ get_date_parts('date') }}
+    FROM insights),
+
+{%- set selected_fields = [
+    "campaign_id",
+    "id",
+    "name",
+    "status",
+    "updated_at"
+] -%}
+{%- set schema_name, table_name = 'googleads_raw', 'ad_groups' -%}
+
+    ad_groups_staging AS
+    (SELECT
+        {% for field in selected_fields|reject("eq","updated_at") -%}
+        {{ get_googleads_clean_field(table_name, field) }}
+        {%- if not loop.last %},{%- endif %}
+        {% endfor -%}
+    FROM
+        (SELECT
+            {{ selected_fields|join(", ") }},
+            MAX(updated_at) OVER (PARTITION BY id) as last_updated_at
+        FROM {{ source(schema_name, table_name) }})
+    WHERE updated_at = last_updated_at
+    ),
+
+{%- set selected_fields = [
+    "customer_id",
+    "id",
+    "name",
+    "status",
+    "advertising_channel_type",
+    "updated_at"
+] -%}
+{%- set schema_name, table_name = 'googleads_raw', 'campaigns' -%}
+
+    campaigns_staging AS
+    (SELECT
+        {% for field in selected_fields|reject("eq","updated_at") -%}
+        {{ get_googleads_clean_field(table_name, field) }}
+        {%- if not loop.last %},{%- endif %}
+        {% endfor -%}
+    FROM
+        (SELECT
+            {{ selected_fields|join(", ") }},
+            MAX(updated_at) OVER (PARTITION BY id) as last_updated_at
+        FROM {{ source(schema_name, table_name) }})
+    WHERE updated_at = last_updated_at
+    ),
+
+{%- set selected_fields = [
+    "id",
+    "descriptive_name",
+    "currency_code",
+    "updated_at"
+] -%}
+{%- set schema_name, table_name = 'googleads_raw', 'accounts' -%}
+
+    accounts_staging AS
+    (SELECT
+        {% for field in selected_fields|reject("eq","updated_at") -%}
+        {{ get_googleads_clean_field(table_name, field) }}
+        {%- if not loop.last %},{%- endif %}
+        {% endfor -%}
+    FROM
+        (SELECT
+            {{ selected_fields|join(", ") }},
+            MAX(updated_at) OVER (PARTITION BY id) as last_updated_at
+        FROM {{ source(schema_name, table_name) }})
+    WHERE updated_at = last_updated_at
+    ),
+
+{%- set date_granularity_list = ['day','week','month','quarter','year'] -%}
+{%- set measure_exclude = ['date','day','week','month','quarter','year','type','last_updated','unique_key','end_date_time','start_date_time'] -%}
+{%- set dimensions = ['ad_group_id'] -%}
+{%- set measures = stg_fields
+                    |reject("in",measure_exclude)
                     |reject("in",dimensions)
                     |list
-                    -%}  
+                    -%}
 
-WITH 
     {%- for date_granularity in date_granularity_list %}
 
-    performance_{{date_granularity}} AS 
-    (SELECT 
+    performance_{{date_granularity}} AS
+    (SELECT
         '{{date_granularity}}' as date_granularity,
         {{date_granularity}} as date,
         {%- for dimension in dimensions %}
@@ -26,30 +194,30 @@ WITH
         COALESCE(SUM("{{ measure }}"),0) as "{{ measure }}"
         {%- if not loop.last %},{%- endif %}
         {% endfor %}
-    FROM {{ ref('googleads_ad_groups_insights') }}
+    FROM insights_stg
     GROUP BY {{ range(1, dimensions|length +2 +1)|list|join(',') }}
     ),
     {%- endfor %}
 
-    ad_groups AS 
-    (SELECT {{ dbt_utils.star(from = ref('googleads_ad_groups'), except = ["unique_key"]) }}
-    FROM {{ ref('googleads_ad_groups') }}
+    ad_groups AS
+    (SELECT campaign_id, ad_group_id, ad_group_name, ad_group_status
+    FROM ad_groups_staging
     ),
 
-   campaigns AS 
-    (SELECT {{ dbt_utils.star(from = ref('googleads_campaigns'), except = ["unique_key"]) }}
-    FROM {{ ref('googleads_campaigns') }}
+    campaigns AS
+    (SELECT account_id, campaign_id, campaign_name, campaign_status, advertising_channel_type
+    FROM campaigns_staging
     ),
-  
-    accounts AS 
-    (SELECT {{ dbt_utils.star(from = ref('googleads_accounts'), except = ["unique_key"]) }}
-    FROM {{ ref('googleads_accounts') }}
+
+    accounts AS
+    (SELECT account_id, account_name, account_currency_code
+    FROM accounts_staging
     )
 
 SELECT *,
     {{ get_googleads_default_campaign_types('campaign_name')}},
     date||'_'||date_granularity||'_'||ad_group_id as unique_key
-FROM 
+FROM
     ({% for date_granularity in date_granularity_list -%}
     SELECT *
     FROM performance_{{date_granularity}}
@@ -58,7 +226,6 @@ FROM
 
     {%- endfor %}
     )
-
 LEFT JOIN ad_groups USING(ad_group_id)
 LEFT JOIN campaigns USING(campaign_id)
 LEFT JOIN accounts USING(account_id)

--- a/models/reporting/googleads_performance_by_asset_group.sql
+++ b/models/reporting/googleads_performance_by_asset_group.sql
@@ -1,22 +1,181 @@
 {{ config (
-    alias = target.database + '_googleads_performance_by_asset_group'
+    alias = target.database + '_googleads_performance_by_asset_group',
+    materialized = 'incremental',
+    unique_key = 'unique_key',
+    incremental_strategy = 'delete+insert',
+    on_schema_change = 'append_new_columns'
 )}}
 
-{%- set date_granularity_list = ['day','week','month','quarter','year'] -%}
-{%- set exclude_fields = ['date','day','week','month','quarter','year','last_updated','unique_key'] -%}
-{%- set dimensions = ['asset_group_id'] -%}
-{%- set measures = adapter.get_columns_in_relation(ref('googleads_asset_groups_insights'))
+{#-
+    Asset group (Performance Max) performance, all date granularities in one table.
+
+    Reads the day-grain incremental staging model directly (no redundant
+    googleads_asset_groups_insights middle table), applies currency conversion +
+    date parts, rolls up day/week/month/quarter/year, and joins asset group +
+    campaign + account metadata built inline. Asset group names/status come from
+    the asset_group_performance_report itself (latest row per id).
+
+    Incremental: daily runs reprocess from the start of the year containing
+    (max date - googleads_lookback_days). Run --full-refresh weekly to rebuild
+    all history and refresh object names/status on older rows.
+-#}
+
+{%- set currency_fields = [
+    "spend"
+]
+-%}
+
+{%- set exclude_fields = [
+    "unique_key",
+    "_fivetran_id",
+    "_fivetran_synced",
+    "customer_time_zone",
+    "campaign",
+    "day_of_week",
+    "last_updated",
+    "asset_group_name",
+    "asset_group_status",
+    "campaign_id",
+    "account_id",
+    "account_currency_code",
+    "campaign_name",
+    "account_name",
+    "campaign_status",
+    "advertising_channel_type",
+    "gmail_saves",
+    "gmail_forwards",
+    "gmail_secondary_clicks",
+    "content_impression_share",
+    "content_budget_lost_impression_share",
+    "content_rank_lost_impression_share",
+    "video_quartile_p_25_rate",
+    "campaign_budget_has_recommended_budget",
+    "campaign_budget_recommended_budget_amount_micros",
+    "campaign_budget",
+    "campaign_budget_period",
+    "campaign_budget_total_amount_micros",
+    "campaign_budget_explicitly_shared",
+    "interactions",
+    "active_view_measurability",
+    "active_view_viewability",
+    "active_view_measurable_cost_micros"
+]
+-%}
+
+{%- set stg_fields = adapter.get_columns_in_relation(ref('_stg_googleads_asset_groups_insights'))
                     |map(attribute="name")
                     |reject("in",exclude_fields)
+                    |list
+                    -%}
+
+WITH
+    {% if var('currency') != 'USD' -%}
+    currency AS
+    (SELECT DISTINCT date, "{{ var('currency') }}" as raw_rate,
+        LAG(raw_rate) ignore nulls over (order by date) as exchange_rate
+    FROM utilities.dates
+    LEFT JOIN utilities.currency USING(date)
+    WHERE date <= current_date),
+    {%- endif -%}
+
+    {%- set exchange_rate = 1 if var('currency') == 'USD' else 'exchange_rate' %}
+
+    insights AS
+    (SELECT
+        {%- for field in stg_fields -%}
+        {%- if field in currency_fields or '_value' in field %}
+        "{{ field }}"::float/{{ exchange_rate }} as "{{ field }}"
+        {%- else %}
+        "{{ field }}"
+        {%- endif -%}
+        {%- if not loop.last %},{%- endif %}
+        {%- endfor %}
+    FROM {{ ref('_stg_googleads_asset_groups_insights') }}
+    {%- if var('currency') != 'USD' %}
+    LEFT JOIN currency USING(date)
+    {%- endif %}
+    {% if is_incremental() -%}
+    where date >= date_trunc('year', (select dateadd(day,-{{ var('googleads_lookback_days', 31) }},max(date)) from {{ this }}))::date
+    {%- endif %}
+    ),
+
+    insights_stg AS
+    (SELECT *,
+    {{ get_date_parts('date') }}
+    FROM insights),
+
+{%- set schema_name, table_name = 'googleads_raw', 'asset_group_performance_report' -%}
+
+    asset_groups_staging AS
+    (SELECT
+        campaign_id,
+        id as asset_group_id,
+        name as asset_group_name,
+        status as asset_group_status,
+        date,
+        MAX(date) OVER (PARTITION BY id) as last_update
+    FROM {{ source(schema_name, table_name) }}
+    ),
+
+{%- set selected_fields = [
+    "customer_id",
+    "id",
+    "name",
+    "status",
+    "advertising_channel_type",
+    "updated_at"
+] -%}
+{%- set schema_name, table_name = 'googleads_raw', 'campaigns' -%}
+
+    campaigns_staging AS
+    (SELECT
+        {% for field in selected_fields|reject("eq","updated_at") -%}
+        {{ get_googleads_clean_field(table_name, field) }}
+        {%- if not loop.last %},{%- endif %}
+        {% endfor -%}
+    FROM
+        (SELECT
+            {{ selected_fields|join(", ") }},
+            MAX(updated_at) OVER (PARTITION BY id) as last_updated_at
+        FROM {{ source(schema_name, table_name) }})
+    WHERE updated_at = last_updated_at
+    ),
+
+{%- set selected_fields = [
+    "id",
+    "descriptive_name",
+    "currency_code",
+    "updated_at"
+] -%}
+{%- set schema_name, table_name = 'googleads_raw', 'accounts' -%}
+
+    accounts_staging AS
+    (SELECT
+        {% for field in selected_fields|reject("eq","updated_at") -%}
+        {{ get_googleads_clean_field(table_name, field) }}
+        {%- if not loop.last %},{%- endif %}
+        {% endfor -%}
+    FROM
+        (SELECT
+            {{ selected_fields|join(", ") }},
+            MAX(updated_at) OVER (PARTITION BY id) as last_updated_at
+        FROM {{ source(schema_name, table_name) }})
+    WHERE updated_at = last_updated_at
+    ),
+
+{%- set date_granularity_list = ['day','week','month','quarter','year'] -%}
+{%- set measure_exclude = ['date','day','week','month','quarter','year','last_updated','unique_key','end_date_time','start_date_time'] -%}
+{%- set dimensions = ['asset_group_id'] -%}
+{%- set measures = stg_fields
+                    |reject("in",measure_exclude)
                     |reject("in",dimensions)
                     |list
-                    -%}  
+                    -%}
 
-WITH 
     {%- for date_granularity in date_granularity_list %}
 
-    performance_{{date_granularity}} AS 
-    (SELECT 
+    performance_{{date_granularity}} AS
+    (SELECT
         '{{date_granularity}}' as date_granularity,
         {{date_granularity}} as date,
         {%- for dimension in dimensions %}
@@ -26,30 +185,31 @@ WITH
         COALESCE(SUM("{{ measure }}"),0) as "{{ measure }}"
         {%- if not loop.last %},{%- endif %}
         {% endfor %}
-    FROM {{ ref('googleads_asset_groups_insights') }}
+    FROM insights_stg
     GROUP BY {{ range(1, dimensions|length +2 +1)|list|join(',') }}
     ),
     {%- endfor %}
 
-    asset_groups AS 
-    (SELECT {{ dbt_utils.star(from = ref('googleads_asset_groups'), except = ["unique_key"]) }}
-    FROM {{ ref('googleads_asset_groups') }}
+    asset_groups AS
+    (SELECT campaign_id, asset_group_id, asset_group_name, asset_group_status
+    FROM asset_groups_staging
+    WHERE date = last_update
     ),
 
-   campaigns AS 
-    (SELECT {{ dbt_utils.star(from = ref('googleads_campaigns'), except = ["unique_key"]) }}
-    FROM {{ ref('googleads_campaigns') }}
+    campaigns AS
+    (SELECT account_id, campaign_id, campaign_name, campaign_status, advertising_channel_type
+    FROM campaigns_staging
     ),
-  
-    accounts AS 
-    (SELECT {{ dbt_utils.star(from = ref('googleads_accounts'), except = ["unique_key"]) }}
-    FROM {{ ref('googleads_accounts') }}
+
+    accounts AS
+    (SELECT account_id, account_name, account_currency_code
+    FROM accounts_staging
     )
 
 SELECT *,
     {{ get_googleads_default_campaign_types('campaign_name')}},
     date||'_'||date_granularity||'_'||asset_group_id as unique_key
-FROM 
+FROM
     ({% for date_granularity in date_granularity_list -%}
     SELECT *
     FROM performance_{{date_granularity}}
@@ -58,7 +218,6 @@ FROM
 
     {%- endfor %}
     )
-
 LEFT JOIN asset_groups USING(asset_group_id)
 LEFT JOIN campaigns USING(campaign_id)
 LEFT JOIN accounts USING(account_id)

--- a/models/reporting/googleads_performance_by_campaign.sql
+++ b/models/reporting/googleads_performance_by_campaign.sql
@@ -1,6 +1,25 @@
 {{ config (
-    alias = target.database + '_googleads_performance_by_campaign'
+    alias = target.database + '_googleads_performance_by_campaign',
+    materialized = 'incremental',
+    unique_key = 'unique_key',
+    incremental_strategy = 'delete+insert',
+    on_schema_change = 'append_new_columns'
 )}}
+
+{#-
+    Campaign performance, all date granularities in one table.
+
+    Reads the day-grain incremental staging model directly (no redundant
+    googleads_campaigns_insights middle table), applies currency conversion +
+    date parts, rolls up day/week/month/quarter/year, and joins campaign +
+    account metadata built inline from the raw history tables.
+
+    Incremental: daily runs reprocess from the start of the year containing
+    (max date - googleads_lookback_days). Reading whole periods keeps the
+    week/month/quarter/year roll-ups complete; data older than the conversion
+    lookback window does not change. Run --full-refresh weekly to rebuild all
+    history and refresh campaign names/status on older rows.
+-#}
 
 {%- set currency_fields = [
     "spend"
@@ -35,30 +54,30 @@
     "active_view_measurability",
     "active_view_viewability",
     "active_view_measurable_cost_micros",
-    "last_updated",
-    "_fivetran_synced"
+    "last_updated"
 ]
 -%}
 
 {%- set stg_fields = adapter.get_columns_in_relation(ref('_stg_googleads_campaigns_insights'))
                     |map(attribute="name")
                     |reject("in",exclude_fields)
-                    -%}  
+                    |list
+                    -%}
 
-WITH 
+WITH
     {% if var('currency') != 'USD' -%}
     currency AS
-    (SELECT DISTINCT date, "{{ var('currency') }}" as raw_rate, 
+    (SELECT DISTINCT date, "{{ var('currency') }}" as raw_rate,
         LAG(raw_rate) ignore nulls over (order by date) as exchange_rate
-    FROM utilities.dates 
+    FROM utilities.dates
     LEFT JOIN utilities.currency USING(date)
     WHERE date <= current_date),
     {%- endif -%}
 
     {%- set exchange_rate = 1 if var('currency') == 'USD' else 'exchange_rate' %}
 
-    insights AS 
-    (SELECT 
+    insights AS
+    (SELECT
         {%- for field in stg_fields -%}
         {%- if field in currency_fields or '_value' in field %}
         "{{ field }}"::float/{{ exchange_rate }} as "{{ field }}"
@@ -71,9 +90,12 @@ WITH
     {%- if var('currency') != 'USD' %}
     LEFT JOIN currency USING(date)
     {%- endif %}
+    {% if is_incremental() -%}
+    where date >= date_trunc('year', (select dateadd(day,-{{ var('googleads_lookback_days', 31) }},max(date)) from {{ this }}))::date
+    {%- endif %}
     ),
 
-    insights_stg AS 
+    insights_stg AS
     (SELECT *,
     {{ get_date_parts('date') }}
     FROM insights),
@@ -88,13 +110,13 @@ WITH
 ] -%}
 {%- set schema_name, table_name = 'googleads_raw', 'campaigns' -%}
 
-    campaigns_staging AS 
-    (SELECT 
+    campaigns_staging AS
+    (SELECT
         {% for field in selected_fields|reject("eq","updated_at") -%}
         {{ get_googleads_clean_field(table_name, field) }}
         {%- if not loop.last %},{%- endif %}
         {% endfor -%}
-    FROM 
+    FROM
         (SELECT
             {{ selected_fields|join(", ") }},
             MAX(updated_at) OVER (PARTITION BY id) as last_updated_at
@@ -110,13 +132,13 @@ WITH
 ] -%}
 {%- set schema_name, table_name = 'googleads_raw', 'accounts' -%}
 
-    accounts_staging AS 
-    (SELECT 
+    accounts_staging AS
+    (SELECT
         {% for field in selected_fields|reject("eq","updated_at") -%}
         {{ get_googleads_clean_field(table_name, field) }}
         {%- if not loop.last %},{%- endif %}
         {% endfor -%}
-    FROM 
+    FROM
         (SELECT
             {{ selected_fields|join(", ") }},
             MAX(updated_at) OVER (PARTITION BY id) as last_updated_at
@@ -125,19 +147,18 @@ WITH
     ),
 
 {%- set date_granularity_list = ['day','week','month','quarter','year'] -%}
-{%- set exclude_fields = ['date','day','week','month','quarter','year','last_updated','unique_key','end_date_time','start_date_time'] -%}
+{%- set measure_exclude = ['date','day','week','month','quarter','year','last_updated','unique_key','end_date_time','start_date_time'] -%}
 {%- set dimensions = ['campaign_id'] -%}
-{%- set measures = adapter.get_columns_in_relation(ref('googleads_campaigns_insights'))
-                    |map(attribute="name")
-                    |reject("in",exclude_fields)
+{%- set measures = stg_fields
+                    |reject("in",measure_exclude)
                     |reject("in",dimensions)
                     |list
-                    -%}  
- 
+                    -%}
+
     {%- for date_granularity in date_granularity_list %}
 
-    performance_{{date_granularity}} AS 
-    (SELECT 
+    performance_{{date_granularity}} AS
+    (SELECT
         '{{date_granularity}}' as date_granularity,
         {{date_granularity}} as date,
         {%- for dimension in dimensions %}
@@ -152,12 +173,12 @@ WITH
     ),
     {%- endfor %}
 
-    campaigns AS 
+    campaigns AS
     (SELECT account_id, campaign_id, campaign_name, campaign_status, advertising_channel_type
     FROM campaigns_staging
     ),
 
-    accounts AS 
+    accounts AS
     (SELECT account_id, account_name, account_currency_code
     FROM accounts_staging
     )
@@ -165,7 +186,7 @@ WITH
 SELECT *,
     {{ get_googleads_default_campaign_types('campaign_name')}},
     date||'_'||date_granularity||'_'||campaign_id as unique_key
-FROM 
+FROM
     ({% for date_granularity in date_granularity_list -%}
     SELECT *
     FROM performance_{{date_granularity}}

--- a/models/reporting/googleads_performance_by_keyword.sql
+++ b/models/reporting/googleads_performance_by_keyword.sql
@@ -1,22 +1,212 @@
 {{ config (
-    alias = target.database + '_googleads_performance_by_keyword'
+    alias = target.database + '_googleads_performance_by_keyword',
+    materialized = 'incremental',
+    unique_key = 'unique_key',
+    incremental_strategy = 'delete+insert',
+    on_schema_change = 'append_new_columns'
 )}}
 
-{%- set date_granularity_list = ['day','week','month','quarter','year'] -%}
-{%- set exclude_fields = ['date','day','week','month','quarter','year','last_updated','unique_key', 'quality_info_creative_score', 'quality_info_post_click_score', 'quality_info_score', 'quality_info_search_predicted_ctr'] -%}
-{%- set dimensions = ['ad_group_id','keyword_id'] -%}
-{%- set measures = adapter.get_columns_in_relation(ref('googleads_keywords_insights'))
+{#-
+    Keyword performance, all date granularities in one table.
+
+    Reads the day-grain incremental staging model directly (no redundant
+    googleads_keywords_insights middle table), applies currency conversion +
+    date parts, rolls up day/week/month/quarter/year, and joins keyword /
+    ad group / campaign / account metadata built inline from the raw history
+    tables.
+
+    Optional stream — off by default; enable per-client (e.g. Erie) by setting
+    +enabled: true on _stg_googleads_keywords_insights and this model.
+
+    Incremental: daily runs reprocess from the start of the year containing
+    (max date - googleads_lookback_days). Run --full-refresh weekly to rebuild
+    history and refresh object names/status on older rows.
+-#}
+
+{%- set currency_fields = [
+    "spend"
+]
+-%}
+
+{%- set exclude_fields = [
+    "unique_key",
+    "_fivetran_id",
+    "_fivetran_synced",
+    "last_updated",
+    "account_id",
+    "account_name",
+    "account_currency_code",
+    "campaign_id",
+    "campaign_name",
+    "ad_group_name",
+    "keyword_status",
+    "keyword_text",
+    "keyword_match_type",
+    "ad_group_criterion_approval_status",
+    "interactions",
+    "engagements",
+    "bounce_rate",
+    "gmail_forwards",
+    "gmail_saves",
+    "gmail_secondary_clicks",
+    "video_quartile_p_25_rate",
+    "active_view_measurable_cost_micros",
+    "quality_info_creative_quality_score",
+    "quality_info_post_click_quality_score",
+    "quality_info_quality_score",
+    "quality_info_search_predicted_ctr"
+]
+-%}
+
+{%- set stg_fields = adapter.get_columns_in_relation(ref('_stg_googleads_keywords_insights'))
                     |map(attribute="name")
                     |reject("in",exclude_fields)
+                    |list
+                    -%}
+
+WITH
+    {% if var('currency') != 'USD' -%}
+    currency AS
+    (SELECT DISTINCT date, "{{ var('currency') }}" as raw_rate,
+        LAG(raw_rate) ignore nulls over (order by date) as exchange_rate
+    FROM utilities.dates
+    LEFT JOIN utilities.currency USING(date)
+    WHERE date <= current_date),
+    {%- endif -%}
+
+    {%- set exchange_rate = 1 if var('currency') == 'USD' else 'exchange_rate' %}
+
+    insights AS
+    (SELECT
+        {%- for field in stg_fields -%}
+        {%- if field in currency_fields or '_value' in field %}
+        "{{ field }}"::float/{{ exchange_rate }} as "{{ field }}"
+        {%- else %}
+        "{{ field }}"
+        {%- endif -%}
+        {%- if not loop.last %},{%- endif %}
+        {%- endfor %}
+    FROM {{ ref('_stg_googleads_keywords_insights') }}
+    {%- if var('currency') != 'USD' %}
+    LEFT JOIN currency USING(date)
+    {%- endif %}
+    {% if is_incremental() -%}
+    where date >= date_trunc('year', (select dateadd(day,-{{ var('googleads_lookback_days', 31) }},max(date)) from {{ this }}))::date
+    {%- endif %}
+    ),
+
+    insights_stg AS
+    (SELECT *,
+    {{ get_date_parts('date') }}
+    FROM insights),
+
+{%- set selected_fields = [
+    "ad_group_id",
+    "id",
+    "keyword_match_type",
+    "keyword_text",
+    "negative",
+    "status",
+    "updated_at"
+] -%}
+{%- set schema_name, table_name = 'googleads_raw', 'keywords' -%}
+
+    keywords_staging AS
+    (SELECT
+        {% for field in selected_fields|reject("eq","updated_at") -%}
+        {{ get_googleads_clean_field(table_name, field) }}
+        {%- if not loop.last %},{%- endif %}
+        {% endfor -%}
+    FROM
+        (SELECT
+            {{ selected_fields|join(", ") }},
+            MAX(updated_at) OVER (PARTITION BY ad_group_id, id) as last_updated_at
+        FROM {{ source(schema_name, table_name) }})
+    WHERE updated_at = last_updated_at
+    ),
+
+{%- set selected_fields = [
+    "campaign_id",
+    "id",
+    "name",
+    "status",
+    "updated_at"
+] -%}
+{%- set schema_name, table_name = 'googleads_raw', 'ad_groups' -%}
+
+    ad_groups_staging AS
+    (SELECT
+        {% for field in selected_fields|reject("eq","updated_at") -%}
+        {{ get_googleads_clean_field(table_name, field) }}
+        {%- if not loop.last %},{%- endif %}
+        {% endfor -%}
+    FROM
+        (SELECT
+            {{ selected_fields|join(", ") }},
+            MAX(updated_at) OVER (PARTITION BY id) as last_updated_at
+        FROM {{ source(schema_name, table_name) }})
+    WHERE updated_at = last_updated_at
+    ),
+
+{%- set selected_fields = [
+    "customer_id",
+    "id",
+    "name",
+    "status",
+    "advertising_channel_type",
+    "updated_at"
+] -%}
+{%- set schema_name, table_name = 'googleads_raw', 'campaigns' -%}
+
+    campaigns_staging AS
+    (SELECT
+        {% for field in selected_fields|reject("eq","updated_at") -%}
+        {{ get_googleads_clean_field(table_name, field) }}
+        {%- if not loop.last %},{%- endif %}
+        {% endfor -%}
+    FROM
+        (SELECT
+            {{ selected_fields|join(", ") }},
+            MAX(updated_at) OVER (PARTITION BY id) as last_updated_at
+        FROM {{ source(schema_name, table_name) }})
+    WHERE updated_at = last_updated_at
+    ),
+
+{%- set selected_fields = [
+    "id",
+    "descriptive_name",
+    "currency_code",
+    "updated_at"
+] -%}
+{%- set schema_name, table_name = 'googleads_raw', 'accounts' -%}
+
+    accounts_staging AS
+    (SELECT
+        {% for field in selected_fields|reject("eq","updated_at") -%}
+        {{ get_googleads_clean_field(table_name, field) }}
+        {%- if not loop.last %},{%- endif %}
+        {% endfor -%}
+    FROM
+        (SELECT
+            {{ selected_fields|join(", ") }},
+            MAX(updated_at) OVER (PARTITION BY id) as last_updated_at
+        FROM {{ source(schema_name, table_name) }})
+    WHERE updated_at = last_updated_at
+    ),
+
+{%- set date_granularity_list = ['day','week','month','quarter','year'] -%}
+{%- set measure_exclude = ['date','day','week','month','quarter','year','last_updated','unique_key','end_date_time','start_date_time','quality_info_creative_score','quality_info_post_click_score','quality_info_score','quality_info_search_predicted_ctr'] -%}
+{%- set dimensions = ['ad_group_id','keyword_id'] -%}
+{%- set measures = stg_fields
+                    |reject("in",measure_exclude)
                     |reject("in",dimensions)
                     |list
-                    -%}  
+                    -%}
 
-WITH 
     {%- for date_granularity in date_granularity_list %}
 
-    performance_{{date_granularity}} AS 
-    (SELECT 
+    performance_{{date_granularity}} AS
+    (SELECT
         '{{date_granularity}}' as date_granularity,
         {{date_granularity}} as date,
         {%- for dimension in dimensions %}
@@ -26,35 +216,35 @@ WITH
         COALESCE(SUM("{{ measure }}"),0) as "{{ measure }}"
         {%- if not loop.last %},{%- endif %}
         {% endfor %}
-    FROM {{ ref('googleads_keywords_insights') }}
+    FROM insights_stg
     GROUP BY {{ range(1, dimensions|length +2 +1)|list|join(',') }}
     ),
     {%- endfor %}
 
-    keywords AS 
+    keywords AS
     (SELECT ad_group_id, keyword_id, keyword_text, keyword_match_type, keyword_status, keyword_negative
-    FROM {{ ref('googleads_keywords') }}
+    FROM keywords_staging
     ),
 
-    ad_groups AS 
-    (SELECT {{ dbt_utils.star(from = ref('googleads_ad_groups'), except = ["unique_key"]) }}
-    FROM {{ ref('googleads_ad_groups') }}
+    ad_groups AS
+    (SELECT campaign_id, ad_group_id, ad_group_name, ad_group_status
+    FROM ad_groups_staging
     ),
 
-    campaigns AS 
-    (SELECT {{ dbt_utils.star(from = ref('googleads_campaigns'), except = ["unique_key"]) }}
-    FROM {{ ref('googleads_campaigns') }}
+    campaigns AS
+    (SELECT account_id, campaign_id, campaign_name, campaign_status, advertising_channel_type
+    FROM campaigns_staging
     ),
 
-    accounts AS 
-    (SELECT {{ dbt_utils.star(from = ref('googleads_accounts'), except = ["unique_key"]) }}
-    FROM {{ ref('googleads_accounts') }}
+    accounts AS
+    (SELECT account_id, account_name, account_currency_code
+    FROM accounts_staging
     )
 
 SELECT *,
     {{ get_googleads_default_campaign_types('campaign_name')}},
     date||'_'||date_granularity||'_'||ad_group_id||'_'||keyword_id as unique_key
-FROM 
+FROM
     ({% for date_granularity in date_granularity_list -%}
     SELECT *
     FROM performance_{{date_granularity}}

--- a/models/reporting/googleads_performance_by_searchterm.sql
+++ b/models/reporting/googleads_performance_by_searchterm.sql
@@ -1,22 +1,199 @@
 {{ config (
-    alias = target.database + '_googleads_performance_by_searchterm'
+    alias = target.database + '_googleads_performance_by_searchterm',
+    materialized = 'incremental',
+    unique_key = 'unique_key',
+    incremental_strategy = 'delete+insert',
+    on_schema_change = 'append_new_columns'
 )}}
 
-{%- set date_granularity_list = ['day','week','month','quarter','year'] -%}
-{%- set exclude_fields = ['date','day','week','month','quarter','year','last_updated','unique_key'] -%}
-{%- set dimensions = ['keyword_ad_group_criterion','search_term','search_term_match_type','search_term_status'] -%}
-{%- set measures = adapter.get_columns_in_relation(ref('googleads_searchterms_insights'))
+{#-
+    Search term performance, all date granularities in one table.
+
+    Reads the day-grain incremental staging model directly (no redundant
+    googleads_searchterms_insights middle table), applies currency conversion +
+    date parts, rolls up day/week/month/quarter/year, and joins keyword /
+    ad group / campaign / account metadata built inline. Search terms are
+    attached to keyword metadata via the reconstructed criterion resource name.
+
+    Optional stream — off by default; enable per-client (e.g. Erie) by setting
+    +enabled: true on _stg_googleads_searchterms_insights and this model.
+
+    Incremental: daily runs reprocess from the start of the year containing
+    (max date - googleads_lookback_days). Run --full-refresh weekly to rebuild
+    history and refresh object names/status on older rows.
+-#}
+
+{%- set currency_fields = [
+    "spend"
+]
+-%}
+
+{%- set exclude_fields = [
+    "unique_key",
+    "_fivetran_id",
+    "_fivetran_synced",
+    "last_updated",
+    "account_id",
+    "account_name",
+    "account_currency_code",
+    "campaign_id",
+    "campaign_name",
+    "interactions",
+    "engagements",
+    "ad_group_id",
+    "ad_group_name",
+    "info_text"
+]
+-%}
+
+{%- set stg_fields = adapter.get_columns_in_relation(ref('_stg_googleads_searchterms_insights'))
                     |map(attribute="name")
                     |reject("in",exclude_fields)
+                    |list
+                    -%}
+
+WITH
+    {% if var('currency') != 'USD' -%}
+    currency AS
+    (SELECT DISTINCT date, "{{ var('currency') }}" as raw_rate,
+        LAG(raw_rate) ignore nulls over (order by date) as exchange_rate
+    FROM utilities.dates
+    LEFT JOIN utilities.currency USING(date)
+    WHERE date <= current_date),
+    {%- endif -%}
+
+    {%- set exchange_rate = 1 if var('currency') == 'USD' else 'exchange_rate' %}
+
+    insights AS
+    (SELECT
+        {%- for field in stg_fields -%}
+        {%- if field in currency_fields or '_value' in field %}
+        "{{ field }}"::float/{{ exchange_rate }} as "{{ field }}"
+        {%- else %}
+        "{{ field }}"
+        {%- endif -%}
+        {%- if not loop.last %},{%- endif %}
+        {%- endfor %}
+    FROM {{ ref('_stg_googleads_searchterms_insights') }}
+    {%- if var('currency') != 'USD' %}
+    LEFT JOIN currency USING(date)
+    {%- endif %}
+    {% if is_incremental() -%}
+    where date >= date_trunc('year', (select dateadd(day,-{{ var('googleads_lookback_days', 31) }},max(date)) from {{ this }}))::date
+    {%- endif %}
+    ),
+
+    insights_stg AS
+    (SELECT *,
+    {{ get_date_parts('date') }}
+    FROM insights),
+
+{%- set selected_fields = [
+    "ad_group_id",
+    "id",
+    "keyword_text",
+    "negative",
+    "status",
+    "updated_at"
+] -%}
+{%- set schema_name, table_name = 'googleads_raw', 'keywords' -%}
+
+    keywords_staging AS
+    (SELECT
+        {% for field in selected_fields|reject("eq","updated_at") -%}
+        {{ get_googleads_clean_field(table_name, field) }}
+        {%- if not loop.last %},{%- endif %}
+        {% endfor -%}
+    FROM
+        (SELECT
+            {{ selected_fields|join(", ") }},
+            MAX(updated_at) OVER (PARTITION BY ad_group_id, id) as last_updated_at
+        FROM {{ source(schema_name, table_name) }})
+    WHERE updated_at = last_updated_at
+    ),
+
+{%- set selected_fields = [
+    "campaign_id",
+    "id",
+    "name",
+    "status",
+    "updated_at"
+] -%}
+{%- set schema_name, table_name = 'googleads_raw', 'ad_groups' -%}
+
+    ad_groups_staging AS
+    (SELECT
+        {% for field in selected_fields|reject("eq","updated_at") -%}
+        {{ get_googleads_clean_field(table_name, field) }}
+        {%- if not loop.last %},{%- endif %}
+        {% endfor -%}
+    FROM
+        (SELECT
+            {{ selected_fields|join(", ") }},
+            MAX(updated_at) OVER (PARTITION BY id) as last_updated_at
+        FROM {{ source(schema_name, table_name) }})
+    WHERE updated_at = last_updated_at
+    ),
+
+{%- set selected_fields = [
+    "customer_id",
+    "id",
+    "name",
+    "status",
+    "advertising_channel_type",
+    "updated_at"
+] -%}
+{%- set schema_name, table_name = 'googleads_raw', 'campaigns' -%}
+
+    campaigns_staging AS
+    (SELECT
+        {% for field in selected_fields|reject("eq","updated_at") -%}
+        {{ get_googleads_clean_field(table_name, field) }}
+        {%- if not loop.last %},{%- endif %}
+        {% endfor -%}
+    FROM
+        (SELECT
+            {{ selected_fields|join(", ") }},
+            MAX(updated_at) OVER (PARTITION BY id) as last_updated_at
+        FROM {{ source(schema_name, table_name) }})
+    WHERE updated_at = last_updated_at
+    ),
+
+{%- set selected_fields = [
+    "id",
+    "descriptive_name",
+    "currency_code",
+    "updated_at"
+] -%}
+{%- set schema_name, table_name = 'googleads_raw', 'accounts' -%}
+
+    accounts_staging AS
+    (SELECT
+        {% for field in selected_fields|reject("eq","updated_at") -%}
+        {{ get_googleads_clean_field(table_name, field) }}
+        {%- if not loop.last %},{%- endif %}
+        {% endfor -%}
+    FROM
+        (SELECT
+            {{ selected_fields|join(", ") }},
+            MAX(updated_at) OVER (PARTITION BY id) as last_updated_at
+        FROM {{ source(schema_name, table_name) }})
+    WHERE updated_at = last_updated_at
+    ),
+
+{%- set date_granularity_list = ['day','week','month','quarter','year'] -%}
+{%- set measure_exclude = ['date','day','week','month','quarter','year','last_updated','unique_key','end_date_time','start_date_time'] -%}
+{%- set dimensions = ['keyword_ad_group_criterion','search_term','search_term_match_type','search_term_status'] -%}
+{%- set measures = stg_fields
+                    |reject("in",measure_exclude)
                     |reject("in",dimensions)
                     |list
-                    -%}  
+                    -%}
 
-WITH 
     {%- for date_granularity in date_granularity_list %}
 
-    performance_{{date_granularity}} AS 
-    (SELECT 
+    performance_{{date_granularity}} AS
+    (SELECT
         '{{date_granularity}}' as date_granularity,
         {{date_granularity}} as date,
         {%- for dimension in dimensions %}
@@ -26,32 +203,32 @@ WITH
         COALESCE(SUM("{{ measure }}"),0) as "{{ measure }}"
         {%- if not loop.last %},{%- endif %}
         {% endfor %}
-    FROM {{ ref('googleads_searchterms_insights') }}
+    FROM insights_stg
     GROUP BY {{ range(1, dimensions|length +2 +1)|list|join(',') }}
     ),
     {%- endfor %}
 
-    ad_groups AS 
-    (SELECT {{ dbt_utils.star(from = ref('googleads_ad_groups'), except = ["unique_key"]) }}
-    FROM {{ ref('googleads_ad_groups') }}
-    ),
-
-    campaigns AS 
-    (SELECT {{ dbt_utils.star(from = ref('googleads_campaigns'), except = ["unique_key"]) }}
-    FROM {{ ref('googleads_campaigns') }}
-    ),
-
-    accounts AS 
-    (SELECT {{ dbt_utils.star(from = ref('googleads_accounts'), except = ["unique_key"]) }}
-    FROM {{ ref('googleads_accounts') }}
-    ),
-
-    keywords AS 
+    keywords AS
     (SELECT ad_group_id, keyword_id, keyword_text, keyword_negative, keyword_status
-    FROM {{ ref('googleads_keywords') }}
+    FROM keywords_staging
     ),
 
-    dimensions AS 
+    ad_groups AS
+    (SELECT campaign_id, ad_group_id, ad_group_name, ad_group_status
+    FROM ad_groups_staging
+    ),
+
+    campaigns AS
+    (SELECT account_id, campaign_id, campaign_name, campaign_status, advertising_channel_type
+    FROM campaigns_staging
+    ),
+
+    accounts AS
+    (SELECT account_id, account_name, account_currency_code
+    FROM accounts_staging
+    ),
+
+    dimensions AS
     (SELECT *,
         'customers/'||account_id::varchar||'/adGroupCriteria/'||ad_group_id::varchar||'~'||keyword_id::varchar as keyword_ad_group_criterion
     FROM keywords
@@ -63,7 +240,7 @@ WITH
 SELECT *,
     {{ get_googleads_default_campaign_types('campaign_name')}},
     date||'_'||date_granularity||'_'||keyword_ad_group_criterion||'_'||search_term||'_'||search_term_match_type as unique_key
-FROM 
+FROM
     ({% for date_granularity in date_granularity_list -%}
     SELECT *
     FROM performance_{{date_granularity}}


### PR DESCRIPTION
Reworks the Google Ads reporting models to the same day-grain → incremental-rollup pattern as the Facebook package, so daily runs are cheap and the heavy redundant tables drop out of each stream's lineage.

## What changed

**All 6 reporting streams** now follow one pattern — `campaign`, `ad_group`, `asset_group`, `ad`, `keyword`, `searchterm`:
- Read their day-grain `_stg_googleads_*_insights` model **directly** (no `googleads_*_insights` "currency + date parts" middle table in the lineage).
- Build campaign / ad-group / asset-group / account (and keyword) **metadata inline** from the raw `*_history` tables — no dependency on the standalone base-metadata models.
- Apply currency conversion + date parts, then roll up day/week/month/quarter/year in one table.
- Are **incremental** (`incremental_strategy='delete+insert'`, `on_schema_change='append_new_columns'`), reprocessing from `date_trunc('year', max(date) - googleads_lookback_days)` so the coarser grains stay complete. A weekly `--full-refresh` rebuilds history and refreshes object names/status.

**Day-grain `_stg` models** (`campaign`, `ad_group`, `asset_group`, `ad`, `keyword`, `searchterm`): lookback window switched from a hardcoded 30 to the new `googleads_lookback_days` var (default **31** = 30-day conversion window + 1 day buffer).

**`dbt_project.yml`**: unchanged from `main` except for adding the `googleads_lookback_days` var. No models are `+enabled: false` (beyond the pre-existing `shopping` disables) — matching the Facebook package, what builds is controlled by `dbt run --select`, not package-level exclusions. This avoids "depends on a node which is disabled" errors in consumers (e.g. `bolt_blueprint`, which wraps `googleads_performance_by_{campaign,ad,asset_group}`).

## Why
- Removes the redundant middle `_insights` tables from each stream's lineage and makes the reporting layer incremental → far less rebuilt per daily run.
- `searchterm` keeps the `keyword_ad_group_criterion` reconstruction for its metadata join, now built from inline staging.

## Reviewer notes
- Unverified against a live warehouse from my side — built by structural parity with the proven core models. Validated on **Erie** (`+googleads_ad_performance`, full-refresh) during the session after fixing a `stg_fields` generator-exhaustion bug in the `ad` model (now materialized with `|list`, consistent with the others).
- Un-refactored models (`geo`, `campaign_product`, `*_legacy`) and the middle/base tables remain enabled and untouched, so nothing downstream breaks.
- Companion (already applied via the Fivetran API, separate from this PR): the active `google_ads` connectors now sync the campaign/ad_group/asset_group performance + convtype reports and `ad_group_history`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)